### PR TITLE
MPI_INCLUDE_ROOT for RHEL/Fedora/Centos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ ifeq ("$(wildcard $(MPI_ROOT))","")
 $(error Could not find MPI in "$(MPI_ROOT)")
 endif
 
+# If MPI_INCLUDE_ROOT has not been set, set it to MPI_ROOT
+ifeq ("$(wildcard $(MPI_INCLUDE_ROOT))","")
+MPI_INCLUDE_ROOT:=$(MPI_ROOT)
+endif
+
 # Check that CUDA path exists.
 ifeq ("$(wildcard $(CUDA_ROOT))","")
 $(error Could not find CUDA in "$(CUDA_ROOT)")
@@ -11,7 +16,7 @@ endif
 CC:=mpic++
 NVCC:=nvcc
 LDFLAGS:=-L$(CUDA_ROOT)/lib64 -L$(MPI_ROOT)/lib -lcudart -lmpi -DOMPI_SKIP_MPICXX=
-CFLAGS:=-std=c++11 -I$(MPI_ROOT)/include -I. -I$(CUDA_ROOT)/include -DOMPI_SKIP_MPICXX=
+CFLAGS:=-std=c++11 -I$(MPI_INCLUDE_ROOT) -I$(MPI_ROOT)/include -I. -I$(CUDA_ROOT)/include -DOMPI_SKIP_MPICXX=
 EXE_NAME:=allreduce-test
 SRC:=$(wildcard *.cpp test/*.cpp)
 CU_SRC:=$(wildcard *.cu)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ To compile `baidu-allreduce`, run
 # Modify CUDA_ROOT to point to your installation of CUDA.
 make MPI_ROOT=/usr/lib/openmpi CUDA_ROOT=/path/to/cuda/lib64
 ```
+For distributions that split their MPI headers and libraries (e.g. RHEL, Fedora, CentOS) into separate directories you should also specify the path to the include files:
+
+```
+MPI_INCLUDE_ROOT=<mpi_include_root>
+```
 
 You may need to modify your `LD_LIBRARY_PATH` environment variable to point to
 your MPI implementation as well as your CUDA libraries.


### PR DESCRIPTION
Some distributions split their libraries and header files into separate directory structures for packages like openmpi.  Add a separate Makefile variable MPI_INCLUDE_ROOT to allow for this split in the same way the issue was solved in DeepBench.  Adding this allows baidu_allreduce to build cleanly on  RHEL/Fedora/CentOS distributions.

Fixes #6 